### PR TITLE
Add Firefox/Edge compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# manifest.json is always ignored since we only care about browser-specific manifests
+# those are named "manifest_[browser].json"
+manifest.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wikifier
-With this Chrome/Firefox extension, search the currently browsed wiki for any selected text.
+With this browser extension, search the currently browsed wiki for any selected text. Compatible with Chrome, Firefox, and Edge.
 
 If your selected text has an exact page on the wiki, the Wikifier brings you directly to it. This is very convenient, since every interesting term on a page is not necessarily "wikilinked" (even when it might have a relevant page).
 
@@ -10,6 +10,10 @@ If your selected text has an exact page on the wiki, the Wikifier brings you dir
 https://chrome.google.com/webstore/detail/wikifier/halpmadjihbhgidkaiikhieggmhjhnac
 
 * From the Firefox Add-ons:
+
+[coming]
+
+* From the Microsoft Edge Add-ons:
 
 [coming]
 
@@ -39,6 +43,15 @@ For unpacked loading, the simplest is to clone or to download the ZIP file of th
 1. Open Mozilla Firefox.
 1. Type `"about:debugging#/runtime/this-firefox"` in the URL bar.
 1. Click on "Load Temporary Add-on..." and target the Wikifier folder.
+
+## Installation on Edge (unpacked)
+
+1. Download and extract the Wikifier folder.
+1. Copy `"manifest_chrome.json"` to `"manifest.json"`.
+1. Open Microsoft Edge.
+1. Type `"edge://extensions/"` in the URL bar.
+1. Enable "Developer mode" in the bottom left.
+1. Click on "Load unpacked" and target the Wikifier folder.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Wikifier
-With this Google Chrome extension, search the currently browsed wiki for any selected text.
+With this Chrome/Firefox extension, search the currently browsed wiki for any selected text.
 
-Install it directly from the Chrome Web Store:
+If your selected text has an exact page on the wiki, the Wikifier brings you directly to it. This is very convenient, since every interesting term on a page is not necessarily "wikilinked" (even when it might have a relevant page).
+
+# Installation
+
+* From the Chrome Web Store:
 
 https://chrome.google.com/webstore/detail/wikifier/halpmadjihbhgidkaiikhieggmhjhnac
+
+* From the Firefox Add-ons:
+
+[coming]
 
 # Using Wikifier
 
@@ -15,13 +23,22 @@ On supported sites (wikipedia.org, wikia.com, fandom.com), just highlight text y
 
 For unpacked loading, the simplest is to clone or to download the ZIP file of the repository.
 
-## Installation (unpacked)
+## Installation on Chrome (unpacked)
 
 1. Download and extract the Wikifier folder.
+1. Copy `"manifest_chrome.json"` to `"manifest.json"`.
 1. Open Google Chrome.
-1. Type "chrome://extensions" in the URL bar.
+1. Type `"chrome://extensions"` in the URL bar.
 1. Enable "Developer mode" in the top right.
 1. Click on "Load unpacked" and target the Wikifier folder.
+
+## Installation on Firefox (unpacked)
+
+1. Download and extract the Wikifier folder.
+1. Copy `"manifest_firefox.json"` to `"manifest.json"`.
+1. Open Mozilla Firefox.
+1. Type `"about:debugging#/runtime/this-firefox"` in the URL bar.
+1. Click on "Load Temporary Add-on..." and target the Wikifier folder.
 
 # License
 

--- a/content_script.js
+++ b/content_script.js
@@ -2,22 +2,7 @@ function downloadNextPage(message, sender, sendResponse) {
 	var url = message.url;
 	var extensionId = message.extensionId;
 	var tabPosition = message.tabPosition;
-    // this unfortunately requires cross-origin request permissions
-	// so we inject it in the page as a content script, which by-pass this limitation
-	
-	// // callback function
-    // function reqListener() {
-    //     console.log("Downloaded " + url);
-	// 	console.log("Extension ID: " + extensionId);
-    //     // send back to the extension the source of the downloaded page
-	// 	chrome.runtime.sendMessage(extensionId, {"url": url, "source": this.responseText, "tabPosition": tabPosition});
-    // }
-
-	// // download the tentative page
-    // var oReq = new XMLHttpRequest();
-    // oReq.addEventListener("load", reqListener);
-    // oReq.open("GET", url);
-    // oReq.send();
+    
     fetch(url)
         .then(response => response.text())
         .then((response) => {

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -1,10 +1,9 @@
 {
 	"name": "Wikifier",
 	"description": "Search the currently browsed wiki for any selected text",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"permissions": [
 		"contextMenus",
-		"declarativeContent",
 		"activeTab",
 		"scripting"
 	],

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -11,9 +11,5 @@
 		"service_worker": "background.js",
 		"type": "module"
 	},
-	"action" :
-	{
-		"default_title" : "Select text in this page and search using the context menu"
-	},
 	"manifest_version": 3
 }

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,0 +1,19 @@
+{
+	"name": "Wikifier",
+	"description": "Search the currently browsed wiki for any selected text",
+	"version": "0.5.3",
+	"permissions": [
+		"contextMenus",
+		"activeTab",
+		"scripting"
+	],
+	"background": {
+		"persistent": false,
+		"scripts": ["background.js"]
+	},
+	"page_action" :
+	{
+		"default_title" : "Select text in this page and search using the context menu"
+	},
+	"manifest_version": 2
+}

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -11,9 +11,5 @@
 		"persistent": false,
 		"scripts": ["background.js"]
 	},
-	"page_action" :
-	{
-		"default_title" : "Select text in this page and search using the context menu"
-	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
* Trim a lot of fat allowing cleaner code and less demanding permissions
* Add second manifest for Firefox (manifest_version: 2 since Firefox doesn't support Manifest v3 yet)
* Test on Edge (can use the manifest for Chrome out-of-the-box, seems to work perfectly)
* Currently uploaded on addons.mozilla.org: https://addons.mozilla.org/en-US/firefox/addon/wikifier/